### PR TITLE
make SB3 compatible with Gym v0.26

### DIFF
--- a/docs/conda_env.yml
+++ b/docs/conda_env.yml
@@ -8,7 +8,7 @@ dependencies:
   - python=3.7
   - pytorch=1.11.0=py3.7_cpu_0
   - pip:
-    - gym==0.25
+    - gym==0.26
     - cloudpickle
     - opencv-python-headless
     - pandas

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -9,6 +9,7 @@ Release 1.6.1a4 (WIP)
 Breaking Changes:
 ^^^^^^^^^^^^^^^^^
 - Switched minimum tensorboard version to 2.9.1
+- Switched gym version to 0.26, implying the new gym API is used from now on.
 
 New Features:
 ^^^^^^^^^^^^^
@@ -1041,4 +1042,4 @@ And all the contributors:
 @Gregwar @ycheng517 @quantitative-technologies @bcollazo @git-thor @TibiGG @cool-RR @MWeltevrede
 @carlosluis @arjun-kg
 @Melanol @qgallouedec @francescoluciano @jlp-ue @burakdmb @timothe-chaumont @honglu2875
-@anand-bala @hughperkins @sidney-tio
+@anand-bala @hughperkins @sidney-tio @tlpss

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     packages=[package for package in find_packages() if package.startswith("stable_baselines3")],
     package_data={"stable_baselines3": ["py.typed", "version.txt"]},
     install_requires=[
-        "gym==0.25",
+        "gym==0.26",
         "numpy",
         "torch>=1.11",
         # For saving models

--- a/stable_baselines3/common/base_class.py
+++ b/stable_baselines3/common/base_class.py
@@ -446,7 +446,11 @@ class BaseAlgorithm(ABC):
 
         # Avoid resetting the environment when calling ``.learn()`` consecutive times
         if reset_num_timesteps or self._last_obs is None:
-            self._last_obs = self.env.reset()  # pytype: disable=annotation-type-mismatch
+            # TODO: should the info dict be saved somewhere?
+            # the step info is dropped in the replay buffer;
+            # but it is saved here in the info buffer
+
+            self._last_obs, _ = self.env.reset()  # pytype: disable=annotation-type-mismatch
             self._last_episode_starts = np.ones((self.env.num_envs,), dtype=bool)
             # Retrieve unnormalized observation for saving into the buffer
             if self._vec_normalize_env is not None:

--- a/stable_baselines3/common/env_checker.py
+++ b/stable_baselines3/common/env_checker.py
@@ -90,7 +90,7 @@ def _check_nan(env: gym.Env) -> None:
     vec_env = VecCheckNan(DummyVecEnv([lambda: env]))
     for _ in range(10):
         action = np.array([env.action_space.sample()])
-        _, _, _, _ = vec_env.step(action)
+        _, _, _, _, _ = vec_env.step(action)
 
 
 def _is_goal_env(env: gym.Env) -> bool:
@@ -197,7 +197,7 @@ def _check_returned_values(env: gym.Env, observation_space: spaces.Space, action
     Check the returned values by the env when calling `.reset()` or `.step()` methods.
     """
     # because env inherits from gym.Env, we assume that `reset()` and `step()` methods exists
-    obs = env.reset()
+    obs, info = env.reset()
 
     if _is_goal_env(env):
         _check_goal_env_obs(obs, observation_space, "reset")
@@ -222,10 +222,10 @@ def _check_returned_values(env: gym.Env, observation_space: spaces.Space, action
     action = action_space.sample()
     data = env.step(action)
 
-    assert len(data) == 4, "The `step()` method must return four values: obs, reward, done, info"
+    assert len(data) == 5, "The `step()` method must return five values: obs, reward, done, truncated, info"
 
     # Unpack
-    obs, reward, done, info = data
+    obs, reward, done, truncated, info = data
 
     if _is_goal_env(env):
         _check_goal_env_obs(obs, observation_space, "step")
@@ -251,6 +251,7 @@ def _check_returned_values(env: gym.Env, observation_space: spaces.Space, action
     # We also allow int because the reward will be cast to float
     assert isinstance(reward, (float, int)), "The reward returned by `step()` must be a float"
     assert isinstance(done, bool), "The `done` signal must be a boolean"
+    assert isinstance(truncated, bool), "The `truncated` signal must be a boolean"
     assert isinstance(info, dict), "The `info` returned by `step()` must be a python dictionary"
 
     # Goal conditioned env

--- a/stable_baselines3/common/envs/bit_flipping_env.py
+++ b/stable_baselines3/common/envs/bit_flipping_env.py
@@ -25,7 +25,7 @@ class BitFlippingEnv(Env):
     :param channel_first: Whether to use channel-first or last image.
     """
 
-    spec = EnvSpec("BitFlippingEnv-v0","no-entry-point")
+    spec = EnvSpec("BitFlippingEnv-v0", "no-entry-point")
 
     def __init__(
         self,
@@ -162,7 +162,7 @@ class BitFlippingEnv(Env):
             self.obs_space.seed(seed)
         self.current_step = 0
         self.state = self.obs_space.sample()
-        return self._get_obs()
+        return self._get_obs(), {}
 
     def step(self, action: Union[np.ndarray, int]) -> GymStepReturn:
         """
@@ -181,8 +181,9 @@ class BitFlippingEnv(Env):
         self.current_step += 1
         # Episode terminate when we reached the goal or the max number of steps
         info = {"is_success": done}
-        done = done or self.current_step >= self.max_steps
-        return obs, reward, done, info
+        truncated = self.current_step >= self.max_steps
+        done = done
+        return obs, reward, done, truncated, info
 
     def compute_reward(
         self, achieved_goal: Union[int, np.ndarray], desired_goal: Union[int, np.ndarray], _info: Optional[Dict[str, Any]]

--- a/stable_baselines3/common/envs/bit_flipping_env.py
+++ b/stable_baselines3/common/envs/bit_flipping_env.py
@@ -25,7 +25,7 @@ class BitFlippingEnv(Env):
     :param channel_first: Whether to use channel-first or last image.
     """
 
-    spec = EnvSpec("BitFlippingEnv-v0")
+    spec = EnvSpec("BitFlippingEnv-v0","no-entry-point")
 
     def __init__(
         self,

--- a/stable_baselines3/common/envs/identity_env.py
+++ b/stable_baselines3/common/envs/identity_env.py
@@ -38,14 +38,15 @@ class IdentityEnv(Env):
         self.current_step = 0
         self.num_resets += 1
         self._choose_next_state()
-        return self.state
+        return self.state, {}
 
     def step(self, action: Union[int, np.ndarray]) -> GymStepReturn:
         reward = self._get_reward(action)
         self._choose_next_state()
         self.current_step += 1
-        done = self.current_step >= self.ep_length
-        return self.state, reward, done, {}
+        truncated = self.current_step >= self.ep_length
+        done = False
+        return self.state, reward, done, truncated, {}
 
     def _choose_next_state(self) -> None:
         self.state = self.action_space.sample()
@@ -75,8 +76,9 @@ class IdentityEnvBox(IdentityEnv):
         reward = self._get_reward(action)
         self._choose_next_state()
         self.current_step += 1
-        done = self.current_step >= self.ep_length
-        return self.state, reward, done, {}
+        truncated = self.current_step >= self.ep_length
+        done = False
+        return self.state, reward, done, truncated, {}
 
     def _get_reward(self, action: np.ndarray) -> float:
         return 1.0 if (self.state - self.eps) <= action <= (self.state + self.eps) else 0.0
@@ -142,13 +144,14 @@ class FakeImageEnv(Env):
         if seed is not None:
             super().reset(seed=seed)
         self.current_step = 0
-        return self.observation_space.sample()
+        return self.observation_space.sample(), {}
 
     def step(self, action: Union[np.ndarray, int]) -> GymStepReturn:
         reward = 0.0
         self.current_step += 1
-        done = self.current_step >= self.ep_length
-        return self.observation_space.sample(), reward, done, {}
+        done = False
+        truncated = self.current_step >= self.ep_length
+        return self.observation_space.sample(), reward, done, truncated, {}
 
     def render(self, mode: str = "human") -> None:
         pass

--- a/stable_baselines3/common/envs/multi_input_envs.py
+++ b/stable_baselines3/common/envs/multi_input_envs.py
@@ -152,11 +152,11 @@ class SimpleMultiObsEnv(gym.Env):
 
         got_to_end = self.state == self.max_state
         reward = 1 if got_to_end else reward
-        done = self.count > self.max_count or got_to_end
-
+        done = got_to_end
+        truncated = self.count > self.max_count
         self.log = f"Went {self.action2str[action]} in state {prev_state}, got to state {self.state}"
 
-        return self.get_state_mapping(), reward, done, {"got_to_end": got_to_end}
+        return self.get_state_mapping(), reward, done, truncated, {"got_to_end": got_to_end}
 
     def render(self, mode: str = "human") -> None:
         """
@@ -180,4 +180,4 @@ class SimpleMultiObsEnv(gym.Env):
             self.state = 0
         else:
             self.state = np.random.randint(0, self.max_state)
-        return self.state_mapping[self.state]
+        return self.state_mapping[self.state], {}

--- a/stable_baselines3/common/type_aliases.py
+++ b/stable_baselines3/common/type_aliases.py
@@ -11,7 +11,8 @@ from stable_baselines3.common import callbacks, vec_env
 
 GymEnv = Union[gym.Env, vec_env.VecEnv]
 GymObs = Union[Tuple, Dict[str, Any], np.ndarray, int]
-GymStepReturn = Tuple[GymObs, float, bool, Dict]
+GymResetReturn = Tuple[GymObs, Dict]
+GymStepReturn = Tuple[GymObs, float, bool, bool, Dict]
 TensorDict = Dict[Union[str, int], th.Tensor]
 OptimizerStateDict = Dict[str, Any]
 MaybeCallback = Union[None, Callable, List[callbacks.BaseCallback], callbacks.BaseCallback]
@@ -44,15 +45,13 @@ class ReplayBufferSamples(NamedTuple):
     actions: th.Tensor
     next_observations: th.Tensor
     dones: th.Tensor
+    truncations: th.Tensor
     rewards: th.Tensor
 
 
 class DictReplayBufferSamples(ReplayBufferSamples):
     observations: TensorDict
-    actions: th.Tensor
     next_observations: TensorDict
-    dones: th.Tensor
-    rewards: th.Tensor
 
 
 class RolloutReturn(NamedTuple):

--- a/stable_baselines3/common/type_aliases.py
+++ b/stable_baselines3/common/type_aliases.py
@@ -45,7 +45,6 @@ class ReplayBufferSamples(NamedTuple):
     actions: th.Tensor
     next_observations: th.Tensor
     dones: th.Tensor
-    truncations: th.Tensor
     rewards: th.Tensor
 
 

--- a/stable_baselines3/common/vec_env/base_vec_env.py
+++ b/stable_baselines3/common/vec_env/base_vec_env.py
@@ -10,12 +10,14 @@ import numpy as np
 # Define type aliases here to avoid circular import
 # Used when we want to access one or more VecEnv
 VecEnvIndices = Union[None, int, Iterable[int]]
-# VecEnvObs is what is returned by the reset() method
-# it contains the observation for each env
+# VecEnvObs contains the observation for each env
 VecEnvObs = Union[np.ndarray, Dict[str, np.ndarray], Tuple[np.ndarray, ...]]
 # VecEnvStepReturn is what is returned by the step() method
-# it contains the observation, reward, done, info for each env
-VecEnvStepReturn = Tuple[VecEnvObs, np.ndarray, np.ndarray, List[Dict]]
+# it contains the observation, reward, done, truncation, info for each env
+VecEnvStepReturn = Tuple[VecEnvObs, np.ndarray, np.ndarray, np.ndarray, List[Dict]]
+# VecEnvResetReturn is what is returned by the reset() method
+# it contains the observation, info for each env
+VecEnvResetReturn = Tuple[VecEnvObs, List[Dict]]
 
 
 def tile_images(img_nhwc: Sequence[np.ndarray]) -> np.ndarray:  # pragma: no cover
@@ -61,7 +63,7 @@ class VecEnv(ABC):
         self.action_space = action_space
 
     @abstractmethod
-    def reset(self) -> VecEnvObs:
+    def reset(self) -> VecEnvResetReturn:
         """
         Reset all the environments and return an array of
         observations, or a tuple of observation arrays.
@@ -70,7 +72,7 @@ class VecEnv(ABC):
         be cancelled and step_wait() should not be called
         until step_async() is invoked again.
 
-        :return: observation
+        :return: observation, info
         """
         raise NotImplementedError()
 
@@ -91,7 +93,7 @@ class VecEnv(ABC):
         """
         Wait for the step taken with step_async().
 
-        :return: observation, reward, done, information
+        :return: observation, reward, done, truncation, information
         """
         raise NotImplementedError()
 
@@ -264,7 +266,7 @@ class VecEnvWrapper(VecEnv):
         self.venv.step_async(actions)
 
     @abstractmethod
-    def reset(self) -> VecEnvObs:
+    def reset(self) -> VecEnvResetReturn:
         pass
 
     @abstractmethod

--- a/stable_baselines3/common/vec_env/vec_check_nan.py
+++ b/stable_baselines3/common/vec_env/vec_check_nan.py
@@ -32,21 +32,21 @@ class VecCheckNan(VecEnvWrapper):
         self.venv.step_async(actions)
 
     def step_wait(self) -> VecEnvStepReturn:
-        observations, rewards, news, infos = self.venv.step_wait()
+        observations, rewards, news, truncations, infos = self.venv.step_wait()
 
         self._check_val(async_step=False, observations=observations, rewards=rewards, news=news)
 
         self._observations = observations
-        return observations, rewards, news, infos
+        return observations, rewards, news, truncations, infos
 
     def reset(self) -> VecEnvObs:
-        observations = self.venv.reset()
+        observations, infos = self.venv.reset()
         self._actions = None
 
         self._check_val(async_step=False, observations=observations)
 
         self._observations = observations
-        return observations
+        return observations, infos
 
     def _check_val(self, *, async_step: bool, **kwargs) -> None:
         # if warn and warn once and have warned once: then stop checking

--- a/stable_baselines3/common/vec_env/vec_extract_dict_obs.py
+++ b/stable_baselines3/common/vec_env/vec_extract_dict_obs.py
@@ -16,9 +16,9 @@ class VecExtractDictObs(VecEnvWrapper):
         super().__init__(venv=venv, observation_space=venv.observation_space.spaces[self.key])
 
     def reset(self) -> np.ndarray:
-        obs = self.venv.reset()
-        return obs[self.key]
+        obs, info = self.venv.reset()
+        return obs[self.key], info
 
     def step_wait(self) -> VecEnvStepReturn:
-        obs, reward, done, info = self.venv.step_wait()
-        return obs[self.key], reward, done, info
+        obs, reward, done, truncated, info = self.venv.step_wait()
+        return obs[self.key], reward, done, truncated, info

--- a/stable_baselines3/common/vec_env/vec_frame_stack.py
+++ b/stable_baselines3/common/vec_env/vec_frame_stack.py
@@ -45,19 +45,19 @@ class VecFrameStack(VecEnvWrapper):
         self,
     ) -> Tuple[Union[np.ndarray, Dict[str, np.ndarray]], np.ndarray, np.ndarray, List[Dict[str, Any]],]:
 
-        observations, rewards, dones, infos = self.venv.step_wait()
+        observations, rewards, dones, truncations, infos = self.venv.step_wait()
 
         observations, infos = self.stackedobs.update(observations, dones, infos)
 
-        return observations, rewards, dones, infos
+        return observations, rewards, dones, truncations, infos
 
     def reset(self) -> Union[np.ndarray, Dict[str, np.ndarray]]:
         """
         Reset all environments
         """
-        observation = self.venv.reset()
+        observation, info = self.venv.reset()
         observation = self.stackedobs.reset(observation)
-        return observation
+        return observation, info
 
     def close(self) -> None:
         self.venv.close()

--- a/stable_baselines3/common/vec_env/vec_transpose.py
+++ b/stable_baselines3/common/vec_env/vec_transpose.py
@@ -92,7 +92,7 @@ class VecTransposeImage(VecEnvWrapper):
         return observations
 
     def step_wait(self) -> VecEnvStepReturn:
-        observations, rewards, dones, infos = self.venv.step_wait()
+        observations, rewards, dones, truncations, infos = self.venv.step_wait()
 
         # Transpose the terminal observations
         for idx, done in enumerate(dones):
@@ -101,13 +101,14 @@ class VecTransposeImage(VecEnvWrapper):
             if "terminal_observation" in infos[idx]:
                 infos[idx]["terminal_observation"] = self.transpose_observations(infos[idx]["terminal_observation"])
 
-        return self.transpose_observations(observations), rewards, dones, infos
+        return self.transpose_observations(observations), rewards, dones, truncations, infos
 
     def reset(self) -> Union[np.ndarray, Dict]:
         """
         Reset all environments
         """
-        return self.transpose_observations(self.venv.reset())
+        observations, infos = self.venv.reset()
+        return self.transpose_observations(observations), infos
 
     def close(self) -> None:
         self.venv.close()

--- a/stable_baselines3/common/vec_env/vec_video_recorder.py
+++ b/stable_baselines3/common/vec_env/vec_video_recorder.py
@@ -64,9 +64,9 @@ class VecVideoRecorder(VecEnvWrapper):
         self.recorded_frames = 0
 
     def reset(self) -> VecEnvObs:
-        obs = self.venv.reset()
+        obs, info = self.venv.reset()
         self.start_video_recorder()
-        return obs
+        return obs, info
 
     def start_video_recorder(self) -> None:
         self.close_video_recorder()
@@ -85,7 +85,7 @@ class VecVideoRecorder(VecEnvWrapper):
         return self.record_video_trigger(self.step_id)
 
     def step_wait(self) -> VecEnvStepReturn:
-        obs, rews, dones, infos = self.venv.step_wait()
+        obs, rews, dones, truncations, infos = self.venv.step_wait()
 
         self.step_id += 1
         if self.recording:
@@ -97,7 +97,7 @@ class VecVideoRecorder(VecEnvWrapper):
         elif self._video_enabled():
             self.start_video_recorder()
 
-        return obs, rews, dones, infos
+        return obs, rews, dones, truncations, infos
 
     def close_video_recorder(self) -> None:
         if self.recording:

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -122,6 +122,8 @@ def test_device_buffer(replay_buffer_cls, device):
         next_obs, reward, done, truncation, info = env.step(action)
         if replay_buffer_cls in [RolloutBuffer, DictRolloutBuffer]:
             episode_start, values, log_prob = np.zeros(1), th.zeros(1), th.ones(1)
+            # here we do not bootstrap the rewards for the rollout buffer for simplicity
+            # see the OnPolicyAlgorithm::collect_rollouts method for how to do this.
             buffer.add(obs, action, reward, episode_start, values, log_prob)
         else:
             buffer.add(obs, next_obs, action, reward, done, truncation, info)

--- a/tests/test_dict_env.py
+++ b/tests/test_dict_env.py
@@ -69,7 +69,8 @@ class DummyDictEnv(gym.Env):
     def step(self, action):
         reward = 0.0
         done = False
-        return self.observation_space.sample(), reward, done, {}
+        truncated = False
+        return self.observation_space.sample(), reward, done, truncated, {}
 
     def compute_reward(self, achieved_goal, desired_goal, info):
         return np.zeros((len(achieved_goal),))
@@ -77,7 +78,7 @@ class DummyDictEnv(gym.Env):
     def reset(self, seed: Optional[int] = None):
         if seed is not None:
             self.observation_space.seed(seed)
-        return self.observation_space.sample()
+        return self.observation_space.sample(), {}
 
     def render(self, mode="human"):
         pass
@@ -109,7 +110,7 @@ def test_consistency(model_class):
     dict_env = gym.wrappers.TimeLimit(dict_env, 100)
     env = gym.wrappers.FlattenObservation(dict_env)
     dict_env.seed(10)
-    obs = dict_env.reset()
+    obs, info = dict_env.reset()
 
     kwargs = {}
     n_steps = 256

--- a/tests/test_env_checker.py
+++ b/tests/test_env_checker.py
@@ -14,11 +14,12 @@ class ActionDictTestEnv(gym.Env):
         observation = np.array([1.0, 1.5, 0.5], dtype=self.observation_space.dtype)
         reward = 1
         done = True
+        truncated = False
         info = {}
-        return observation, reward, done, info
+        return observation, reward, done, truncated, info
 
     def reset(self):
-        return np.array([1.0, 1.5, 0.5], dtype=self.observation_space.dtype)
+        return np.array([1.0, 1.5, 0.5], dtype=self.observation_space.dtype), {"random_dict_arg": np.array([1.2])}
 
     def render(self, mode="human"):
         pass

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -98,7 +98,7 @@ def test_high_dimension_action_space():
 
     # Patch to avoid error
     def patched_step(_action):
-        return env.observation_space.sample(), 0.0, False, {}
+        return env.observation_space.sample(), 0.0, False, False, {}
 
     env.step = patched_step
     check_env(env)
@@ -127,10 +127,10 @@ def test_non_default_spaces(new_obs_space):
     env = FakeImageEnv()
     env.observation_space = new_obs_space
     # Patch methods to avoid errors
-    env.reset = new_obs_space.sample
+    env.reset = lambda: (new_obs_space.sample(), {})
 
     def patched_step(_action):
-        return new_obs_space.sample(), 0.0, False, {}
+        return new_obs_space.sample(), 0.0, False, False, {}
 
     env.step = patched_step
     with pytest.warns(UserWarning):
@@ -193,7 +193,7 @@ def check_reset_assert_error(env, new_reset_return):
     """
 
     def wrong_reset():
-        return new_reset_return
+        return new_reset_return, {}
 
     # Patch the reset method with a wrong one
     env.reset = wrong_reset
@@ -223,10 +223,10 @@ def test_common_failures_reset():
     wrong_obs = {**env.observation_space.sample(), "extra_key": None}
     check_reset_assert_error(env, wrong_obs)
 
-    obs = env.reset()
+    obs, _ = env.reset()
 
     def wrong_reset(self):
-        return {"img": obs["img"], "vec": obs["img"]}
+        return {"img": obs["img"], "vec": obs["img"]}, {}
 
     env.reset = types.MethodType(wrong_reset, env)
     with pytest.raises(AssertionError) as excinfo:
@@ -259,33 +259,33 @@ def test_common_failures_step():
     env = IdentityEnvBox()
 
     # Wrong shape for the observation
-    check_step_assert_error(env, (np.ones((4,)), 1.0, False, {}))
+    check_step_assert_error(env, (np.ones((4,)), 1.0, False, False, {}))
     # Obs is not a numpy array
-    check_step_assert_error(env, (1, 1.0, False, {}))
+    check_step_assert_error(env, (1, 1.0, False, False, {}))
 
     # Return a wrong reward
-    check_step_assert_error(env, (env.observation_space.sample(), np.ones(1), False, {}))
+    check_step_assert_error(env, (env.observation_space.sample(), np.ones(1), False, False, {}))
 
     # Info dict is not returned
-    check_step_assert_error(env, (env.observation_space.sample(), 0.0, False))
+    check_step_assert_error(env, (env.observation_space.sample(), 0.0, False, False))
 
-    # Done is not a boolean
-    check_step_assert_error(env, (env.observation_space.sample(), 0.0, 3.0, {}))
-    check_step_assert_error(env, (env.observation_space.sample(), 0.0, 1, {}))
+    # Done/truncated is not a boolean
+    check_step_assert_error(env, (env.observation_space.sample(), 0.0, 3.0, False, {}))
+    check_step_assert_error(env, (env.observation_space.sample(), 0.0, False, 3.0, {}))
 
     env = SimpleMultiObsEnv()
 
     # Observation keys and observation space keys must match
     wrong_obs = env.observation_space.sample()
     wrong_obs.pop("img")
-    check_step_assert_error(env, (wrong_obs, 0.0, False, {}))
+    check_step_assert_error(env, (wrong_obs, 0.0, False, False, {}))
     wrong_obs = {**env.observation_space.sample(), "extra_key": None}
-    check_step_assert_error(env, (wrong_obs, 0.0, False, {}))
+    check_step_assert_error(env, (wrong_obs, 0.0, False, False, {}))
 
-    obs = env.reset()
+    obs, _ = env.reset()
 
     def wrong_step(self, action):
-        return {"img": obs["vec"], "vec": obs["vec"]}, 0.0, False, {}
+        return {"img": obs["vec"], "vec": obs["vec"]}, 0.0, False, False, {}
 
     env.step = types.MethodType(wrong_step, env)
     with pytest.raises(AssertionError) as excinfo:

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -22,10 +22,10 @@ def test_monitor(tmp_path):
     ep_lengths = []
     ep_len, ep_reward = 0, 0
     for _ in range(total_steps):
-        _, reward, done, _ = monitor_env.step(monitor_env.action_space.sample())
+        _, reward, done, truncated, _ = monitor_env.step(monitor_env.action_space.sample())
         ep_len += 1
         ep_reward += reward
-        if done:
+        if done or truncated:
             ep_rewards.append(ep_reward)
             ep_lengths.append(ep_len)
             monitor_env.reset()
@@ -66,8 +66,8 @@ def test_monitor_load_results(tmp_path):
     monitor_env1.reset()
     episode_count1 = 0
     for _ in range(1000):
-        _, _, done, _ = monitor_env1.step(monitor_env1.action_space.sample())
-        if done:
+        _, _, done, truncated, _ = monitor_env1.step(monitor_env1.action_space.sample())
+        if done or truncated:
             episode_count1 += 1
             monitor_env1.reset()
 
@@ -89,8 +89,8 @@ def test_monitor_load_results(tmp_path):
         monitor_env2 = Monitor(env2, monitor_file2, override_existing=False)
         monitor_env2.reset()
         for _ in range(1000):
-            _, _, done, _ = monitor_env2.step(monitor_env2.action_space.sample())
-            if done:
+            _, _, done, truncated, _ = monitor_env2.step(monitor_env2.action_space.sample())
+            if done or truncated:
                 episode_count2 += 1
                 monitor_env2.reset()
 

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -343,8 +343,8 @@ def test_save_load_replay_buffer(tmp_path, model_class):
     assert np.allclose(old_replay_buffer.actions, model.replay_buffer.actions)
     assert np.allclose(old_replay_buffer.rewards, model.replay_buffer.rewards)
     assert np.allclose(old_replay_buffer.dones, model.replay_buffer.dones)
-    assert np.allclose(old_replay_buffer.timeouts, model.replay_buffer.timeouts)
-    infos = [[{"TimeLimit.truncated": truncated}] for truncated in old_replay_buffer.timeouts]
+    assert np.allclose(old_replay_buffer.truncations, model.replay_buffer.truncations)
+    infos = [[{"TimeLimit.truncated": truncated}] for truncated in old_replay_buffer.truncations]
 
     # test extending replay buffer
     model.replay_buffer.extend(
@@ -353,6 +353,7 @@ def test_save_load_replay_buffer(tmp_path, model_class):
         old_replay_buffer.actions,
         old_replay_buffer.rewards,
         old_replay_buffer.dones,
+        old_replay_buffer.truncations,
         infos,
     )
 
@@ -377,7 +378,6 @@ def test_warn_buffer(recwarn, model_class, optimize_memory_usage):
         optimize_memory_usage=optimize_memory_usage,
         # we cannot use optimize_memory_usage and handle_timeout_termination
         # at the same time
-        replay_buffer_kwargs={"handle_timeout_termination": not optimize_memory_usage},
         policy_kwargs=dict(net_arch=[64]),
         learning_starts=10,
     )

--- a/tests/test_spaces.py
+++ b/tests/test_spaces.py
@@ -18,10 +18,10 @@ class DummyMultiDiscreteSpace(gym.Env):
     def reset(self, seed: Optional[int] = None):
         if seed is not None:
             super().reset(seed=seed)
-        return self.observation_space.sample()
+        return self.observation_space.sample(), {}
 
     def step(self, action):
-        return self.observation_space.sample(), 0.0, False, {}
+        return self.observation_space.sample(), 0.0, False, False, {}
 
 
 class DummyMultiBinary(gym.Env):
@@ -33,10 +33,10 @@ class DummyMultiBinary(gym.Env):
     def reset(self, seed: Optional[int] = None):
         if seed is not None:
             super().reset(seed=seed)
-        return self.observation_space.sample()
+        return self.observation_space.sample(), {}
 
     def step(self, action):
-        return self.observation_space.sample(), 0.0, False, {}
+        return self.observation_space.sample(), 0.0, False, False, {}
 
 
 class DummyMultidimensionalAction(gym.Env):
@@ -46,10 +46,10 @@ class DummyMultidimensionalAction(gym.Env):
         self.action_space = gym.spaces.Box(low=-1, high=1, shape=(2, 2), dtype=np.float32)
 
     def reset(self):
-        return self.observation_space.sample()
+        return self.observation_space.sample(), {}
 
     def step(self, action):
-        return self.observation_space.sample(), 0.0, False, {}
+        return self.observation_space.sample(), 0.0, False, False, {}
 
 
 @pytest.mark.parametrize("model_class", [SAC, TD3, DQN])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,9 +53,9 @@ def test_make_atari_env(env_id, n_envs, wrapper_kwargs):
 
     assert env.num_envs == n_envs
 
-    obs = env.reset()
+    obs, _ = env.reset()
 
-    new_obs, reward, _, _ = env.step([env.action_space.sample() for _ in range(n_envs)])
+    new_obs, reward, _, _, _ = env.step([env.action_space.sample() for _ in range(n_envs)])
 
     assert obs.shape == new_obs.shape
 
@@ -194,14 +194,14 @@ class AlwaysDoneWrapper(gym.Wrapper):
         obs, reward, done, info = self.env.step(action)
         self.needs_reset = done
         self.last_obs = obs
-        return obs, reward, True, info
+        return obs, reward, True, False, info
 
     def reset(self, **kwargs):
         if self.needs_reset:
             obs = self.env.reset(**kwargs)
             self.last_obs = obs
             self.needs_reset = False
-        return self.last_obs
+        return self.last_obs, {}
 
 
 @pytest.mark.parametrize("n_envs", [1, 2, 5, 7])

--- a/tests/test_vec_check_nan.py
+++ b/tests/test_vec_check_nan.py
@@ -24,11 +24,11 @@ class NanAndInfEnv(gym.Env):
             obs = float("inf")
         else:
             obs = 0
-        return [obs], 0.0, False, {}
+        return [obs], 0.0, False, False, {}
 
     @staticmethod
     def reset():
-        return [0.0]
+        return [0.0], {}
 
     def render(self, mode="human", close=False):
         pass

--- a/tests/test_vec_extract_dict_obs.py
+++ b/tests/test_vec_extract_dict_obs.py
@@ -23,11 +23,12 @@ class DictObsVecEnv:
             {"rgb": np.zeros((self.num_envs, 86, 86))},
             np.zeros((self.num_envs,)),
             np.zeros((self.num_envs,), dtype=bool),
+            np.zeros((self.num_envs,), dtype=bool),
             [{} for _ in range(self.num_envs)],
         )
 
     def reset(self):
-        return {"rgb": np.zeros((self.num_envs, 86, 86))}
+        return {"rgb": np.zeros((self.num_envs, 86, 86))}, {}
 
     def render(self, mode="human", close=False):
         pass
@@ -38,7 +39,7 @@ def test_extract_dict_obs():
 
     env = DictObsVecEnv()
     env = VecExtractDictObs(env, "rgb")
-    assert env.reset().shape == (4, 86, 86)
+    assert env.reset()[0].shape == (4, 86, 86)
 
 
 def test_vec_with_ppo():

--- a/tests/test_vec_monitor.py
+++ b/tests/test_vec_monitor.py
@@ -27,7 +27,7 @@ def test_vec_monitor(tmp_path):
     total_steps = 1000
     ep_len, ep_reward = 0, 0
     for _ in range(total_steps):
-        _, rewards, dones, infos = monitor_env.step([monitor_env.action_space.sample()])
+        _, rewards, dones, truncations, infos = monitor_env.step([monitor_env.action_space.sample()])
         ep_len += 1
         ep_reward += rewards[0]
         if dones[0]:
@@ -61,8 +61,8 @@ def test_vec_monitor_info_keywords(tmp_path):
     monitor_env.reset()
     total_steps = 1000
     for _ in range(total_steps):
-        _, _, dones, infos = monitor_env.step([monitor_env.action_space.sample()])
-        if dones[0]:
+        _, _, dones, truncations, infos = monitor_env.step([monitor_env.action_space.sample()])
+        if dones[0] or truncations[0]:
             assert "is_success" in infos[0]["episode"]
 
     monitor_env.close()
@@ -96,8 +96,8 @@ def test_vec_monitor_load_results(tmp_path):
     monitor_env1.reset()
     episode_count1 = 0
     for _ in range(1000):
-        _, _, dones, _ = monitor_env1.step([monitor_env1.action_space.sample()])
-        if dones[0]:
+        _, _, dones, truncations, _ = monitor_env1.step([monitor_env1.action_space.sample()])
+        if dones[0] or truncations[0]:
             episode_count1 += 1
             monitor_env1.reset()
 
@@ -116,8 +116,8 @@ def test_vec_monitor_load_results(tmp_path):
     monitor_env2.reset()
     episode_count2 = 0
     for _ in range(1000):
-        _, _, dones, _ = monitor_env2.step([monitor_env2.action_space.sample()])
-        if dones[0]:
+        _, _, dones, truncations, _ = monitor_env2.step([monitor_env2.action_space.sample()])
+        if dones[0] or truncations[0]:
             episode_count2 += 1
             monitor_env2.reset()
 


### PR DESCRIPTION
## Description
gym v26 makes all changes in API from v22 on mandatory. Most notably:
-  the `reset` now returns `obs,info` 
-  the step returns `obs, reward, terminated, truncated, info`
- the reset takes an optional argument `seed`, the dedicated `seed()` function is removed.


This requires following changes:
- [x] Update the Buffers to handle this new API
  - [x] ReplayBuffer
  - [x] RolloutBuffers
- [ ] Update all custom Envs in the repo to the new API
- [x] Update all Interfaces (such as DummyVencEnv) that interact with gym envs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
continues #780

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**)
- [ ] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
